### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A data analysis site by flask and mongoengine
 <img src="https://dl.dropboxusercontent.com/u/95512723/images/12.png" border="0" />
 
 
-####USEAGE
+#### USEAGE
 
 ```
 $pip install -r requirements.txt


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
